### PR TITLE
VZ-11614: Build Dex v2.37.0 using Go 1.20.12

### DIFF
--- a/Dockerfile_verrazzano
+++ b/Dockerfile_verrazzano
@@ -1,11 +1,15 @@
 ARG BASE_IMAGE=ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230811160107-63554aa
 ARG FINAL_IMAGE=ghcr.io/verrazzano/ol8-static:v0.0.1-20231102152128-e7afc807
-FROM $BASE_IMAGE AS builder
+ARG GO_LANG_IMAGE=ghcr.io/verrazzano/golang:v1.20.12
 
-RUN microdnf install -y go-toolset make git && \
-    microdnf --enablerepo ol8_codeready_builder install glibc-static && \
-    microdnf clean all && \
-    rm -rf /var/cache/yum/*
+FROM $GO_LANG_IMAGE AS builder
+
+RUN dnf config-manager --enable ol8_appstream && \
+    dnf install make git && \
+    dnf config-manager --enable ol8_codeready_builder && \
+    dnf install glibc-static && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 WORKDIR /usr/local/src/dex
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ PROTOC_GEN_GO_VERSION      = 1.28.1
 PROTOC_GEN_GO_GRPC_VERSION = 1.3.0
 
 VZ_BASE_IMAGE ?= ghcr.io/verrazzano/verrazzano-base:v1.0.0-20230727050514-6b5fb42
+GO_LANG_IMAGE ?= ghcr.io/verrazzano/golang:v1.20.12
 
 DOCKER_IMAGE_NAME ?= ${PROJ}-dev
 DOCKER_IMAGE_TAG ?= local-$(shell git rev-parse --short HEAD)
@@ -49,6 +50,7 @@ release-binary: ## Build release binaries (used to build a final container image
 docker-build: ## Build docker image
 	docker build --pull -f Dockerfile_verrazzano \
 		   --build-arg BASE_IMAGE="${VZ_BASE_IMAGE}" \
+                   --build-arg GO_LANG_IMAGE="${GO_LANG_IMAGE}" \
 		   -t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
 bin/dex:
 	@mkdir -p bin/

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ release-binary: ## Build release binaries (used to build a final container image
 docker-build: ## Build docker image
 	docker build --pull -f Dockerfile_verrazzano \
 		   --build-arg BASE_IMAGE="${VZ_BASE_IMAGE}" \
-                   --build-arg GO_LANG_IMAGE="${GO_LANG_IMAGE}" \
+		   --build-arg GO_LANG_IMAGE="${GO_LANG_IMAGE}" \
 		   -t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} .
 bin/dex:
 	@mkdir -p bin/


### PR DESCRIPTION
Builds Dex v2.37.0 using Go 1.20.12